### PR TITLE
chore: use public repository URL

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git@github.com:hyperse-io/ts-node.git"
+    "url": "git+https://github.com/hyperse-io/ts-node.git"
   },
   "type": "module",
   "exports": {


### PR DESCRIPTION
## Summary

- Update the package repository URL from SSH-style GitHub syntax to public HTTPS.

This is a metadata-only change. It does not change runtime code, dependencies, lockfiles, versions, or entry points.

## Validation

- Metadata assertion: `repository.url` is now `git+https://github.com/hyperse-io/ts-node.git`
- `git diff --check`
- `yarn install --immutable --mode=skip-build` with Yarn 4.13.0
- `yarn build`
- `yarn typecheck`
- `yarn test` (11 files, 51 tests)
- `yarn lint`
- `yarn pack --dry-run`

Notes:

- Yarn install currently reports existing peer dependency warnings.
- `npm pack --dry-run --package-lock=false` fails locally inside the Yarn PnP install with an npm/arborist `Cannot read properties of null (reading 'package')` error, so I used the repository package manager for the pack dry-run.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated repository URL configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->